### PR TITLE
Make sure destination exists before copying files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,9 +10,12 @@ else
   DEST_DIR="$HOME/.local/share/icons"
 fi
 
-cp -r dist/ $DEST_DIR/Layan-cursors
-cp -r dist-border/ $DEST_DIR/Layan-border-cursors
-cp -r dist-white/ $DEST_DIR/Layan-white-cursors
+# ensure the destination exists
+mkdir -p "$DEST_DIR"
+
+cp -r dist/ "$DEST_DIR"/Layan-cursors
+cp -r dist-border/ "$DEST_DIR"/Layan-border-cursors
+cp -r dist-white/ "$DEST_DIR"/Layan-white-cursors
 
 echo "Finished..."
 


### PR DESCRIPTION
I made this quite some time ago and completely forgot about it, basically some folders don't exist by default so it just makes sure they exist before trying to copy